### PR TITLE
adjust to changes in implint vars in SCIP 10

### DIFF
--- a/ipet/parsing/StatisticReader_VariableReader.py
+++ b/ipet/parsing/StatisticReader_VariableReader.py
@@ -21,7 +21,8 @@ class VariableReader(StatisticReader):
     name = 'VariableReader'
     varexp = re.compile(r'^  Variables        :')
     consexp = re.compile(r'^  Constraints      :')
-    varkeys = ['Vars', 'BinVars', 'IntVars', 'ImplVars', 'ContVars']
+    varkeys_old = ['Vars', 'BinVars', 'IntVars', 'ImplVars', 'ContVars']
+    varkeys_new = ['Vars', 'BinVars', 'IntVars', 'ContVars']
     conskeys = ["InitialNCons", "MaxNCons"]
     problemtype = None
     
@@ -35,8 +36,11 @@ class VariableReader(StatisticReader):
      
         # check if the SCIP variable expression is matched by line
         elif self.problemtype and self.varexp.match(line):
-            nvariables = list(map(int, misc.numericExpression.findall(line)[:len(self.varkeys)]))
-            datakeys = ["%s_%s" % (self.problemtype, key) for key in self.varkeys]
+            nvariables = list(map(int, misc.numericExpression.findall(line)[:len(self.varkeys_old)]))
+            if len(nvariables) == len(self.varkeys_old) :
+               datakeys = ["%s_%s" % (self.problemtype, key) for key in self.varkeys_old]
+            else :
+               datakeys = ["%s_%s" % (self.problemtype, key) for key in self.varkeys_new]
             self.addData(datakeys, nvariables)
 
         # check if the constraint expression is matched by line


### PR DESCRIPTION
#implicit integer variables no longer printed on same line as other variable types.

This is a patch we currently apply to the iPET used in ZIB's Rubberband server.