### PR TITLE
Fixes pandas deprecation warnings

### DIFF
--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1031,7 +1031,7 @@ class IPETEvaluation(IpetNode):
 
                     newvals = tmpgroup[comparecolname]
 
-                    df[comparecolname].update(newvals)
+                    df[comparecolname] = df[comparecolname].update(newvals)
 
                 df.reset_index(drop = False, inplace = True)
                 usercolumns.append(comparecolname)

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1863,7 +1863,7 @@ class IPETEvaluation(IpetNode):
         else:
             generalpart = df[indices].pivot_table(index = self.getColIndex(),
                     dropna = False,
-                    aggfunc = sum)
+                    aggfunc = 'sum')
 
         # test if there is any aggregation to be calculated
         activecolumns = self.getActiveColumns()

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -29,6 +29,11 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+def to_numeric_wrapper(s):
+  try:
+     return pd.to_numeric(s, errors='raise')
+  except ValueError:
+     return s
 
 class IPETEvaluationColumn(IpetNode):
 
@@ -1809,11 +1814,11 @@ class IPETEvaluation(IpetNode):
         self.rettab = ret
 
         # cast all numeric columns back
-        self.rettab = self.rettab.apply(pd.to_numeric, errors = 'ignore')
-        self.retagg = self.retagg.apply(pd.to_numeric, errors = 'ignore')
+        self.rettab = self.rettab.apply(to_numeric_wrapper)
+        self.retagg = self.retagg.apply(to_numeric_wrapper)
         for d in [self.filtered_agg, self.filtered_instancewise]:
             for k, v in d.items():
-                d[k] = v.apply(pd.to_numeric, errors = 'ignore')
+                d[k] = v.apply(to_numeric_wrapper)
 
         self.setEvaluated(True)
         return self.rettab, self.retagg

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1107,8 +1107,9 @@ class IPETEvaluation(IpetNode):
             raise AttributeError("Index not unique, cannot fill in data. Exiting.")
         newdata = data.set_index(self.getIndex()).reindex(newind).reset_index()
 
-        newdata["_miss_"].fillna(value=True, inplace=True)
-        newdata[Key.ProblemStatus].fillna(Key.ProblemStatusCodes.Missing, inplace=True)
+        with pd.option_context("future.no_silent_downcasting", True):
+            newdata["_miss_"] = newdata["_miss_"].fillna(value=True).infer_objects(copy=False)
+        newdata[Key.ProblemStatus] = newdata[Key.ProblemStatus].fillna(Key.ProblemStatusCodes.Missing)
 
         return newdata
 

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1008,6 +1008,9 @@ class IPETEvaluation(IpetNode):
                 compcol = dict(list(grouped))[dg]
                 comparecolname = col.getCompareColName()
 
+                logger.warning(f'{comparecolname}')
+                logger.warning(f'compare column: {col}')
+                logger.warning(f'dataframe {df[comparecolname]}')
                 # apply the correct comparison method to the original and the temporary column
                 compmethod = col.getCompareMethod()
                 method = lambda x:compmethod(*x)

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1031,7 +1031,10 @@ class IPETEvaluation(IpetNode):
 
                     newvals = tmpgroup[comparecolname]
 
-                    df[comparecolname] = df[comparecolname].update(newvals)
+                    # we are updating the values of comparecolname in df with
+                    # newvals. This is possible because newvals has the column
+                    # name comparecolname.
+                    df.update(newvals)
 
                 df.reset_index(drop = False, inplace = True)
                 usercolumns.append(comparecolname)

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1008,9 +1008,6 @@ class IPETEvaluation(IpetNode):
                 compcol = dict(list(grouped))[dg]
                 comparecolname = col.getCompareColName()
 
-                logger.warning(f'{comparecolname}')
-                logger.warning(f'compare column: {col}')
-                logger.warning(f'dataframe {df[comparecolname]}')
                 # apply the correct comparison method to the original and the temporary column
                 compmethod = col.getCompareMethod()
                 method = lambda x:compmethod(*x)

--- a/ipet/evaluation/IPETFilter.py
+++ b/ipet/evaluation/IPETFilter.py
@@ -625,8 +625,9 @@ class IPETFilterGroup(IpetNode):
         dfindex = df.set_index(index).index
 
         groups = df.groupby(index)
-        instancecount = groups.apply(len).max()
-        interrows = groups.apply(lambda x:len(x) == instancecount)
+        instancecount = groups.apply(len, include_groups=False).max()
+        interrows = groups.apply(lambda x:len(x) == instancecount,
+                                 include_groups=False)
 
         return interrows.reindex(dfindex)
 

--- a/ipet/evaluation/IPETFilter.py
+++ b/ipet/evaluation/IPETFilter.py
@@ -283,7 +283,7 @@ class IPETFilter(IpetNode):
 
     def applyValueOperator(self, df):
 
-        dtype = df.dtypes[0]
+        dtype = df.dtypes.iloc[0]
 
         self.checkAndUpdateValueSet(dtype)
         contained = df.isin(self.valueset)


### PR DESCRIPTION
Closes #3.

- Handles exceptions in `to_numeric` with a wrapper function
- uses 'sum' as aggfunc to use the internal pandas sum method
- uses `iloc` to access series by position
- passes `include_groups=False` in the `groups.apply` method
- removes the use of `inplace` in `apply` methods.